### PR TITLE
ci: Add staging deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,6 @@ defaults:
     shell: bash -el {0}
 
 jobs:
-  prod-deployment:
-    name: Publish release
-    runs-on: ubuntu-latest
-    if: github.event_name == 'release'
-    steps:
-      - name: Trigger deploy webhook
-        run: curl ${{ secrets.VERCEL_DEPLOY_HOOK_URL_RELEASE }}
-
   database-migration:
     name: Database migration
     runs-on: ubuntu-latest
@@ -50,3 +42,27 @@ jobs:
         run: pnpx prisma migrate deploy
         env:
           POSTGRES_URL: ${{ github.event_name == 'release' && secrets.PROD_POSTGRES_URL || secrets.STAGING_POSTGRES_URL }}
+
+  # syncing main to staging branch (as vercel deployments are branch based)
+  staging-deployment:
+    name: Deploy to staging
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      # force update staging to main
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Update staging branch
+        run: |
+          git fetch origin
+          git checkout -B staging origin/main
+          git push -f origin staging
+
+  # represents the main branch, but not deployed on merge (see vercel.json)
+  prod-deployment:
+    name: Publish release
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+      - name: Trigger deploy webhook
+        run: curl ${{ secrets.VERCEL_DEPLOY_HOOK_URL_RELEASE }}

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,8 @@
     "installCommand": "pnpm install",
     "git": {
         "deploymentEnabled": {
-            "main": false
+            "main": false,
+            "staging": true
         }
     }
   }


### PR DESCRIPTION
To support a staging deployment in Vercel, we need a branch representing it. As the state of the main branch should reflect the stating and the production deployment should only be triggered on release, we have to use the main branch for the prod deployment. However, we won't trigger prod deployments on merge to main (disabled in `vercel.json`), but only on release via the `release.yml` workflow.