### PR TITLE
chore: Switch to HTTP based deployment triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,11 +63,10 @@ jobs:
           git checkout -B staging origin/main
           git push -f origin staging
 
-  # represents the main branch, but not deployed on merge (see vercel.json)
   prod-deployment:
     name: Publish release
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
     steps:
       - name: Trigger deploy webhook
-        run: curl ${{ secrets.VERCEL_DEPLOY_HOOK_URL_RELEASE }}
+        run: curl ${{ github.event_name == 'release' && secrets.PROD_VERCEL_DEPLOY_HOOK_URL || secrets.STAGING_VERCEL_DEPLOY_HOOK_URL}}

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
     "git": {
         "deploymentEnabled": {
             "main": false,
-            "staging": true
+            "staging": false
         }
     }
   }


### PR DESCRIPTION
# Motivation

On staging vercel didn't deploy on merge when the merging person wasn't part of the vercel team. Adding people there is to expensive though. Switching to http based triggers.